### PR TITLE
Controls: add derivative to long loop and improve Toyota Prius long tuning

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -144,6 +144,7 @@ class CarInterfaceBase(ABC):
     ret.longitudinalTuning.deadzoneBP = [0.]
     ret.longitudinalTuning.deadzoneV = [0.]
     ret.longitudinalTuning.kf = 1.
+    ret.longitudinalTuning.kd = 0.
     ret.longitudinalTuning.kpBP = [0.]
     ret.longitudinalTuning.kpV = [1.]
     ret.longitudinalTuning.kiBP = [0.]

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -144,11 +144,12 @@ class CarInterfaceBase(ABC):
     ret.longitudinalTuning.deadzoneBP = [0.]
     ret.longitudinalTuning.deadzoneV = [0.]
     ret.longitudinalTuning.kf = 1.
-    ret.longitudinalTuning.kd = 0.
     ret.longitudinalTuning.kpBP = [0.]
     ret.longitudinalTuning.kpV = [1.]
     ret.longitudinalTuning.kiBP = [0.]
     ret.longitudinalTuning.kiV = [1.]
+    ret.longitudinalTuning.kdBP = [0.]
+    ret.longitudinalTuning.kdV = [0.]
     # TODO estimate car specific lag, use .15s for now
     ret.longitudinalActuatorDelayLowerBound = 0.15
     ret.longitudinalActuatorDelayUpperBound = 0.15

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -317,16 +317,17 @@ class CarInterface(CarInterfaceBase):
     # to a negative value, so it won't matter.
     ret.minEnableSpeed = -1. if (stop_and_go or ret.enableGasInterceptor) else MIN_ACC_SPEED
 
-    if ret.enableGasInterceptor and not candidate in FULL_SPEED_DRCC_CAR:
-      set_long_tune(ret.longitudinalTuning, LongTunes.PEDAL)
-    elif candidate in TSS2_CAR or candidate == CAR.CAMRYH:
-      set_long_tune(ret.longitudinalTuning, LongTunes.TSS2)
-      ret.stoppingDecelRate = 0.3  # reach stopping target smoothly
-    elif candidate in (RADAR_ACC_CAR_TSS1 - RADAR_ACC_CAR_TSS1_NEW_TUNE) \
-         or (params.get_bool("EndToEndLong") and candidate not in TSS2_CAR):
-      set_long_tune(ret.longitudinalTuning, LongTunes.TSSStock)
+    # Longitudinal Tunes
+    ret.stoppingDecelRate = 0.3  # reach stopping target smoothly
+
+    if candidate == CAR.PRIUS:
+      set_long_tune(ret.longitudinalTuning, LongTunes.TSSPPrius) # TSS-P Toyota Prius has a special tune
+    elif candidate in (CAR.CAMRY, CAR.CAMRYH):
+      set_long_tune(ret.longitudinalTuning, LongTunes.TSSPCamry) # TSS-P Toyota Camry / Camry H have a special tune
+    elif (candidate in TSS2_CAR) or (ret.enableGasInterceptor and not candidate in FULL_SPEED_DRCC_CAR):
+      set_long_tune(ret.longitudinalTuning, LongTunes.TSS2) # Use TSS 2.0 tune for both pedal and TSS 2.0 cars
     else:
-      set_long_tune(ret.longitudinalTuning, LongTunes.TSSBetter)
+      set_long_tune(ret.longitudinalTuning, LongTunes.TSSStock) # Use stock TSS-P tune for all other cars
 
     return ret
 

--- a/selfdrive/car/toyota/tunes.py
+++ b/selfdrive/car/toyota/tunes.py
@@ -29,6 +29,8 @@ class LatTunes(Enum):
 
 ###### LONG ######
 def set_long_tune(tune, name):
+  tune.deadzoneBP = [0., 9.]
+  tune.deadzoneV = [.0, .15]
   # Improved longitudinal tune
   if name == LongTunes.TSS2 or name == LongTunes.PEDAL:
     tune.kpBP = [0., 5., 20.]

--- a/selfdrive/car/toyota/tunes.py
+++ b/selfdrive/car/toyota/tunes.py
@@ -39,10 +39,11 @@ def set_long_tune(tune, name):
     tune.kiV = [.35, .23, .20, .17, .1]
   # Default longitudinal tune
   elif name == LongTunes.TSSBetter:
-    tune.kpBP = [0., 5., 35.]
-    tune.kiBP = [0., 35.]
-    tune.kpV = [1.5, 1.5, 1.0]
-    tune.kiV = [0.54, 0.36]
+    tune.kpBP = [0.]
+    tune.kiBP = [0.]
+    tune.kpV = [0.]
+    tune.kiV = [0.]
+    tune.kd = [0.]
   elif name == LongTunes.TSSStock:
     tune.kpBP = [0., 5., 35.]
     tune.kiBP = [0., 35.]

--- a/selfdrive/car/toyota/tunes.py
+++ b/selfdrive/car/toyota/tunes.py
@@ -2,11 +2,10 @@
 from enum import Enum
 
 class LongTunes(Enum):
-  PEDAL = 0
-  TSS2 = 1
-  TSSBetter = 2
-  TSSStock = 3
-  TSSPCamry = 4
+  TSS2 = 0
+  TSSPPrius = 1
+  TSSStock = 2
+  TSSPCamry = 3
 
 class LatTunes(Enum):
   INDI_PRIUS = 0
@@ -32,19 +31,19 @@ def set_long_tune(tune, name):
   tune.deadzoneBP = [0., 9., 12.]
   tune.deadzoneV = [.1, .15, 0.]
   # Improved longitudinal tune
-  if name == LongTunes.TSS2 or name == LongTunes.PEDAL:
+  if name == LongTunes.TSS2:
     tune.kpBP = [0., 5., 20.]
     tune.kpV = [1.3, 1.0, 0.7]
     tune.kiBP = [0., 5., 12., 20., 27.]
     tune.kiV = [.35, .23, .20, .17, .1]
   # Default longitudinal tune
-  elif name == LongTunes.TSSBetter:
+  elif name == LongTunes.TSSPPrius:
     tune.kpBP = [0.]
     tune.kiBP = [0.]
-    tune.kdBP = [0.]
-    tune.kpV = [0.]
-    tune.kiV = [0.]
-    tune.kdV = [0.]
+    tune.kdBP = [0., 16., 20.]
+    tune.kpV = [1.2]
+    tune.kiV = [0.36]
+    tune.kdV = [0.25, 0.3, 0.4]
   elif name == LongTunes.TSSStock:
     tune.kpBP = [0., 5., 35.]
     tune.kiBP = [0., 35.]

--- a/selfdrive/car/toyota/tunes.py
+++ b/selfdrive/car/toyota/tunes.py
@@ -29,8 +29,8 @@ class LatTunes(Enum):
 
 ###### LONG ######
 def set_long_tune(tune, name):
-  tune.deadzoneBP = [0., 9.]
-  tune.deadzoneV = [.1, .15]
+  tune.deadzoneBP = [0., 9., 12.]
+  tune.deadzoneV = [.1, .15, 0.]
   # Improved longitudinal tune
   if name == LongTunes.TSS2 or name == LongTunes.PEDAL:
     tune.kpBP = [0., 5., 20.]

--- a/selfdrive/car/toyota/tunes.py
+++ b/selfdrive/car/toyota/tunes.py
@@ -30,7 +30,7 @@ class LatTunes(Enum):
 ###### LONG ######
 def set_long_tune(tune, name):
   tune.deadzoneBP = [0., 9.]
-  tune.deadzoneV = [.0, .15]
+  tune.deadzoneV = [.075, .15]
   # Improved longitudinal tune
   if name == LongTunes.TSS2 or name == LongTunes.PEDAL:
     tune.kpBP = [0., 5., 20.]

--- a/selfdrive/car/toyota/tunes.py
+++ b/selfdrive/car/toyota/tunes.py
@@ -41,9 +41,10 @@ def set_long_tune(tune, name):
   elif name == LongTunes.TSSBetter:
     tune.kpBP = [0.]
     tune.kiBP = [0.]
+    tune.kdBP = [0.]
     tune.kpV = [0.]
     tune.kiV = [0.]
-    tune.kd = [0.]
+    tune.kdV = [0.]
   elif name == LongTunes.TSSStock:
     tune.kpBP = [0., 5., 35.]
     tune.kiBP = [0., 35.]

--- a/selfdrive/car/toyota/tunes.py
+++ b/selfdrive/car/toyota/tunes.py
@@ -41,7 +41,7 @@ def set_long_tune(tune, name):
   elif name == LongTunes.TSSBetter:
     tune.kpBP = [0., 5., 35.]
     tune.kiBP = [0., 35.]
-    tune.kpV = [1.6, 1.4, 1.2]
+    tune.kpV = [1.6, 1.5, 0.7]
     tune.kiV = [0.54, 0.36]
   elif name == LongTunes.TSSStock:
     tune.kpBP = [0., 5., 35.]

--- a/selfdrive/car/toyota/tunes.py
+++ b/selfdrive/car/toyota/tunes.py
@@ -39,7 +39,7 @@ def set_long_tune(tune, name):
   elif name == LongTunes.TSSBetter:
     tune.kpBP = [0., 5., 35.]
     tune.kiBP = [0., 35.]
-    tune.kpV = [1.8, 1.5, 1.0]
+    tune.kpV = [1.6, 1.4, 1.2]
     tune.kiV = [0.54, 0.36]
   elif name == LongTunes.TSSStock:
     tune.kpBP = [0., 5., 35.]

--- a/selfdrive/car/toyota/tunes.py
+++ b/selfdrive/car/toyota/tunes.py
@@ -30,7 +30,7 @@ class LatTunes(Enum):
 ###### LONG ######
 def set_long_tune(tune, name):
   tune.deadzoneBP = [0., 9.]
-  tune.deadzoneV = [.075, .15]
+  tune.deadzoneV = [.1, .15]
   # Improved longitudinal tune
   if name == LongTunes.TSS2 or name == LongTunes.PEDAL:
     tune.kpBP = [0., 5., 20.]
@@ -41,7 +41,7 @@ def set_long_tune(tune, name):
   elif name == LongTunes.TSSBetter:
     tune.kpBP = [0., 5., 35.]
     tune.kiBP = [0., 35.]
-    tune.kpV = [1.6, 1.5, 0.7]
+    tune.kpV = [1.5, 1.5, 1.0]
     tune.kiV = [0.54, 0.36]
   elif name == LongTunes.TSSStock:
     tune.kpBP = [0., 5., 35.]

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -45,7 +45,8 @@ class LongControl():
     self.long_control_state = LongCtrlState.off  # initialized to off
     self.pid = PIDController((CP.longitudinalTuning.kpBP, CP.longitudinalTuning.kpV),
                              (CP.longitudinalTuning.kiBP, CP.longitudinalTuning.kiV),
-                             k_f = CP.longitudinalTuning.kf, k_d = CP.longitudinalTuning.kd, 
+                             (CP.longitudinalTuning.kdBP, CP.longitudinalTuning.kdV),
+                             k_f = CP.longitudinalTuning.kf,
                              rate=1 / DT_CTRL)
     self.v_pid = 0.0
     self.last_output_accel = 0.0

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -45,8 +45,8 @@ class LongControl():
     self.long_control_state = LongCtrlState.off  # initialized to off
     self.pid = PIDController((CP.longitudinalTuning.kpBP, CP.longitudinalTuning.kpV),
                              (CP.longitudinalTuning.kiBP, CP.longitudinalTuning.kiV),
-                             (CP.longitudinalTuning.kdBP, CP.longitudinalTuning.kdV),
                              k_f = CP.longitudinalTuning.kf,
+                             k_d = (CP.longitudinalTuning.kdBP, CP.longitudinalTuning.kdV),
                              rate=1 / DT_CTRL)
     self.v_pid = 0.0
     self.last_output_accel = 0.0

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -45,7 +45,8 @@ class LongControl():
     self.long_control_state = LongCtrlState.off  # initialized to off
     self.pid = PIDController((CP.longitudinalTuning.kpBP, CP.longitudinalTuning.kpV),
                              (CP.longitudinalTuning.kiBP, CP.longitudinalTuning.kiV),
-                             k_f = CP.longitudinalTuning.kf, rate=1 / DT_CTRL)
+                             k_f = CP.longitudinalTuning.kf, k_d = CP.longitudinalTuning.kd, 
+                             rate=1 / DT_CTRL)
     self.v_pid = 0.0
     self.last_output_accel = 0.0
 


### PR DESCRIPTION
This PR adds a derivative gain to the longitudinal "pi" loop, making it a pid loop for massively improved stability, responsiveness, and ease of tuning. New tune tested and applied to a TSS-P Toyota Prius only.